### PR TITLE
Fix typos in IRT chapters

### DIFF
--- a/book/TT/6_Dichotomous_IRT/0_Introduction.md
+++ b/book/TT/6_Dichotomous_IRT/0_Introduction.md
@@ -16,6 +16,6 @@ kernelspec:
 
 ## Measurement models for Dichotomous scores 
 
-In today session we will first learn how to work with `rpy2`, then how to perform the first necessary step in IRT based analysis, such as assessing the dimentionality of a given questionaire. And focus on dychotomous scored items and their anaylsis using Rasch, 2-PL, and (briefly) 3-PL models.
+In today's session we will first learn how to work with `rpy2`, then perform the first necessary step in IRT‑based analysis—assessing the dimensionality of a given questionnaire. We then focus on dichotomously scored items and their analysis using Rasch, 2‑PL and (briefly) 3‑PL models.
 
 

--- a/book/TT/6_Dichotomous_IRT/2_dicho.ipynb
+++ b/book/TT/6_Dichotomous_IRT/2_dicho.ipynb
@@ -6,7 +6,7 @@
     "id": "0dtwBaFyRwzF"
    },
    "source": [
-    "# 4.1 Assessing Dimentionality\n",
+  "# 4.1 Assessing Dimensionality\n",
     "\n",
     "We first start with activating the environment and import the required R and Python packages.\n",
     "Since we already set up and tested our environment in the first session, everything should work smoothly."
@@ -130,7 +130,7 @@
     "# Set random seed for reproducibility\n",
     "ro.r('set.seed(123)')\n",
     "\n",
-    "# Ipython extenrsion for magix plotting\n",
+  "# IPython extension for magic plotting\n",
     "%load_ext rpy2.ipython\n",
     "\n",
     "# R imports\n",

--- a/book/TT/6_Dichotomous_IRT/3_irt.ipynb
+++ b/book/TT/6_Dichotomous_IRT/3_irt.ipynb
@@ -692,7 +692,7 @@
     "At this point we can conclude that our data fit the Rasch model. This gives our\n",
     "scale the highest seal of approval. Thus, we can interpret the item parameters and,\n",
     "finally, elaborate on what (parallel) ICCs are.\n",
-    "To do so, use the Rash model fited on only the valid items and print the parameters\n",
+    "To do so, use the Rasch model fitted on only the valid items and print the parameters\n",
     "in a sorted manner: "
    ]
   },
@@ -817,7 +817,7 @@
     "First of all, we see that all ICCs are parallel, and all of them have a slope of 1.\n",
     "This is an implication of the Rasch model which will be relaxed in the next section.\n",
     "The plot shows that `subtr1` is the easiest item, since it is located furthest to the left\n",
-    "on the trait, meaning that it is the item that requires the lowest amount of latent train to have a probability of being scored correctly of 1. `subtr3` is to the far right and consequently the most difficult one. In\n",
+    "on the trait, meaning that it is the item that requires the lowest amount of latent trait to have a probability of being scored correctly of 1. `subtr3` is to the far right and consequently the most difficult one. In\n",
     "this plot, the item parameters are reflected the value on the x-axis for which the\n",
     "endorsement probability is exactly 0.5. In the plot, this is demonstrated for `subtr3`."
    ]

--- a/book/TT/6_Dichotomous_IRT/4_Exercises.ipynb
+++ b/book/TT/6_Dichotomous_IRT/4_Exercises.ipynb
@@ -18,9 +18,9 @@
     "## 1️⃣ Dimensionality assessment\n",
     "**Instructions:**\n",
     "- Download and load the dataset\n",
-    "- Test unidimensionality on the addition items of the `zareki` dataset.\n",
-    "- What conclusion can you draw from the results of the analysis?\n",
-    "- Is there any items that seems to violate unidimentionality? If so, remove it and run the analysis again, what has changed?"
+  "- Test unidimensionality on the addition items of the `zareki` dataset.\n",
+  "- What conclusion can you draw from the results of the analysis?\n",
+  "- Are there any items that seem to violate unidimensionality? If so, remove them and run the analysis again. What has changed?"
    ]
   },
   {
@@ -46,7 +46,7 @@
    "source": [
     "## 2️⃣: The Rasch model\n",
     "**Instructions:**\n",
-    "- Analyse the item parameters of a Rasch model on all the matematical items in the `zareski` dataset\n",
+  "- Analyze the item parameters of a Rasch model on all the mathematical items in the `zareki` dataset\n",
     "    - Assess general model fit\n",
     "    - Assess misfit at the item level\n",
     "    - Clean the dataset and re-fit the Rasch model\n",

--- a/book/TT/7_Polythomous_IRT/0_Introduction.md
+++ b/book/TT/7_Polythomous_IRT/0_Introduction.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-# <i class="fa-solid fa-cubes"></i> Polythomous
+# <i class="fa-solid fa-cubes"></i> Polytomous
 
 ## Measurement models for Polytomous scores
 

--- a/book/TT/7_Polythomous_IRT/1_Rating_Scale_Model.ipynb
+++ b/book/TT/7_Polythomous_IRT/1_Rating_Scale_Model.ipynb
@@ -460,7 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Discard all participatns with missing data \n",
+    "# Discard all participants with missing data \n",
     "CEAQ = CEAQ.replace(-2147483648, np.nan)      # Replace -2147483648 with NaN\n",
     "CEAQ = CEAQ.dropna()                          # Drop rows with NaN values\n",
     "itceaq = CEAQ.iloc[:, :16] - 1                # Subtract 1 from every response to make the dataset eRm compatible\n",


### PR DESCRIPTION
## Summary
- clean up typos in dichotomous IRT introduction
- rename "Polythomous" heading
- clarify bullet points in exercises
- fix typos inside dichotomous IRT notebooks
- correct a comment in rating scale model notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c1cd0450832790c84db4ee774738